### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ beautifulsoup4==4.12.3
 openai==1.40.3
 python-dotenv==1.0.1
 lxml==5.3.0 
+httpx==0.27.2


### PR DESCRIPTION
OpenAIのPython SDKは内部でhttpxを使っていますが、httpx 0.28系からは`Client(proxies=…)`引数が完全に削除されました。ところが、OpenAI SDK（1.x系の多くのバージョン、たとえば1.87.0）はまだ`proxies`を渡そうとするため、httpxを0.28以上にすると次のようなエラーが起こります。

　TypeError: Client.__init__() got an unexpected keyword argument 'proxies'

httpxのメンテナは公式に「proxiesは0.26で非推奨、0.28で削除。暫定的な対処として`httpx==0.27.2`に固定してください」と案内しています。